### PR TITLE
ILICHECK-23 fix upload folder path

### DIFF
--- a/src/ILICheck.Web/Controllers/UploadController.cs
+++ b/src/ILICheck.Web/Controllers/UploadController.cs
@@ -114,8 +114,11 @@ namespace ILICheck.Web.Controllers
             return UploadResult;
         }
 
-        private void MakeUploadFolder(string connectionId) =>
-            Directory.CreateDirectory(configuration.GetUploadPathForSession(connectionId));
+        private void MakeUploadFolder(string connectionId)
+        {
+            UploadFolderPath = configuration.GetUploadPathForSession(connectionId);
+            Directory.CreateDirectory(UploadFolderPath);
+        }
 
         private async Task DoTaskWhileSendingUpdatesAsync(Task task, string connectionId, string updateMessage)
         {


### PR DESCRIPTION
Restores [previous behaviour](https://github.com/GeoWerkstatt/interlis-check-service/pull/6/commits/0fd6cd0930651a3162780a795c2b7b2b625929b0#diff-31732e115a34e4949aceebc561f0a6fcc581bd8137163757f9e4819a9734a686L116-R118).