### PR TITLE
ILICHECK-7 remove Docker tags filter

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -35,7 +35,7 @@ jobs:
             org.opencontainers.image.version=v${{ env.VERSION }}
             org.opencontainers.image.maintainer=GeoWerkstatt GmbH <support@geowerkstatt.ch>
           tags: |
-            type=edge,branch=main
+            type=edge
 
       - name: Log in to the GitHub container registry
         uses: docker/login-action@v1


### PR DESCRIPTION
in order to allow pre-release builds on every branch.