### PR TITLE
ILICHECK-53 remove GeoW in-house specific information

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,6 @@ Folgenden Komponenten müssen auf dem Entwicklungsrechner installiert sein:
    `IIS Express` Launch-Profil im Visual Studio resp. Visual Studio Code mit F5 starten  
    _Hinweis: Damit in der lokalen Entwicklungsumgebung der ilivalidator-Aufruf aus dem .NET Backend erfolgen kann, muss vorgängig das [docker-compose.yml](./docker-compose.yml) mit `docker-compose up` gestartet werden._
 
-## Testumgebung (GeoWerkstatt intern)
-
-* [INTERLIS Web-Check-Service](https://ilicheck.geow.cloud/)-Webapplikation
-* Webbasierter [Datei Explorer](https://ilicheck-filebrowser.geow.cloud/files/) um hochgeladene XTF Transferdateien und Validierungslogs anzuzeigen. (Die Zugangsdaten befinden sich im GeoWerkstatt Keepass)
-
 ## Neue Version erstellen
 
 Ein neuer GitHub _Pre-release_ wird bei jeder Änderung auf [main](https://github.com/GeoWerkstatt/interlis-check-service) [automatisch](./.github/workflows/pre-release.yml) erstellt. In diesem Kontext wird auch ein neues Docker Image mit dem Tag _:edge_ erstellt und in die [GitHub Container Registry (ghcr.io)](https://github.com/geowerkstatt/interlis-check-service/pkgs/container/interlis-check-service) gepusht. Der definitve Release erfolgt, indem die Checkbox _This is a pre-release_ eines beliebigen Pre-releases entfernt wird. In der Folge wird das entsprechende Docker Image in der ghcr.io Registry mit den Tags (bspw.: _:v1_, _:v1.2.3_ und _:latest_) [ergänzt](./.github/workflows/release.yml).


### PR DESCRIPTION
Im Kontext der Veröffentlichung des Projekts müssen diese Informationen entfernt werden. Die GeoW-interne Testumgebung wird bereits [hier](https://github.com/GeoWerkstatt/geow-infrastructure#services) dokumentiert. 