### PR TITLE
ILICHECK-114 fix broken ilivalidator transfer file names

### DIFF
--- a/ilivalidator-wrapper.sh
+++ b/ilivalidator-wrapper.sh
@@ -22,4 +22,4 @@ exec {BASH_XTRACEFD}> >(sudo tee /proc/1/fd/2)
 set -x #echo on
 
 # Execute ilivalidator with the given options
-java -jar $ILIVALIDATOR_HOME_DIR/$ILIVALIDATOR_VERSION/ilivalidator-$ILIVALIDATOR_VERSION.jar $OPTIONS $TRANSFER_FILE_NAME
+java -jar $ILIVALIDATOR_HOME_DIR/$ILIVALIDATOR_VERSION/ilivalidator-$ILIVALIDATOR_VERSION.jar $OPTIONS "$TRANSFER_FILE_NAME"

--- a/src/ILICheck.Web/Controllers/UploadController.cs
+++ b/src/ILICheck.Web/Controllers/UploadController.cs
@@ -310,7 +310,7 @@ namespace ILICheck.Web.Controllers
             var xtfLogPath = uploadPath + "/ilivalidator_output.xtf";
 
             var commandPrefix = configuration.GetSection("Validation")["CommandPrefix"];
-            var command = $"ilivalidator --log {logPath} --xtflog {xtfLogPath} {filePath}";
+            var command = $"ilivalidator --log {logPath} --xtflog {xtfLogPath} \"{filePath}\"";
 
             var startInfo = new ProcessStartInfo()
             {


### PR DESCRIPTION
There was an issue with transfer files containing whitespace characters in file name.