### PR TITLE
ILICHECK-115 restore connection properly

### DIFF
--- a/src/ILICheck.Web/ClientApp/src/app.js
+++ b/src/ILICheck.Web/ClientApp/src/app.js
@@ -33,10 +33,8 @@ function App() {
     async function start() {
       try {
         await connection.start().then(() => {
-          if (connection.connectionId) {
-            connection.invoke('SendConnectionId', connection.connectionId);
-          }
-        }).catch((e) => console.log('Error: ', e));
+          if (connection.connectionId) connection.invoke('SendConnectionId', connection.connectionId);
+        });
       } catch (err) {
         console.log(err);
         setTimeout(start, 5000);


### PR DESCRIPTION
Remove promise-style catch block. Otherwise, the try-/catch block won't work as expected and the SignalR connection doesn't get restored properly.