### PR TITLE
Fix Node.js kann nicht installiert werden in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-c"]
 
 # Install Node.js
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl gnupg && \
+    apt-get install -y gnupg && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     NODE_MAJOR=20 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,15 @@ ARG REVISION
 SHELL ["/bin/bash", "-c"]
 
 # Install Node.js
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get install -y nodejs
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    NODE_MAJOR=20 && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install nodejs -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Restore dependencies and tools
 COPY ["src/ILICheck.Web/ILICheck.Web.csproj", "ILICheck.Web/"]


### PR DESCRIPTION
Resolves #168

Folgt den Anweisungen von https://github.com/nodesource/distributions#installation-instructions und installiert Node.js Version 20 (aktuelle LTS).