### PR TITLE
Sanitize user input

### DIFF
--- a/src/ILICheck.Web/Controllers/DownloadController.cs
+++ b/src/ILICheck.Web/Controllers/DownloadController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 using System;
+using System.Web;
 
 namespace ILICheck.Web.Controllers
 {
@@ -35,7 +36,7 @@ namespace ILICheck.Web.Controllers
 
             try
             {
-                logger.LogInformation("Log file (<{LogType}>) for job identifier <{JobId}> requested.", logType, jobId);
+                logger.LogInformation("Log file (<{LogType}>) for job identifier <{JobId}> requested.", HttpUtility.HtmlEncode(logType), jobId);
                 return File(fileProvider.OpenText(fileProvider.GetLogFile(logType)).BaseStream, "text/xml; charset=utf-8");
             }
             catch (Exception)

--- a/src/ILICheck.Web/Controllers/UploadController.cs
+++ b/src/ILICheck.Web/Controllers/UploadController.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
+using System.Web;
 using static ILICheck.Web.ValidatorHelper;
 
 namespace ILICheck.Web.Controllers
@@ -85,7 +86,7 @@ namespace ILICheck.Web.Controllers
             var httpRequest = httpContextAccessor.HttpContext.Request;
 
             logger.LogInformation("Start uploading <{TransferFile}> to <{HomeDirectory}>", file.FileName, fileProvider.HomeDirectory);
-            logger.LogInformation("Transfer file size: {ContentLength}", httpRequest.ContentLength);
+            logger.LogInformation("Transfer file size: {ContentLength}", HttpUtility.HtmlEncode(httpRequest.ContentLength));
             logger.LogInformation("Start time: {Timestamp}", DateTime.Now);
 
             try


### PR DESCRIPTION
This resolves [2 active](https://github.com/GeoWerkstatt/interlis-check-service/security/code-scanning) code scanning CodeQL errors.