### PR TITLE
Slack logs

### DIFF
--- a/src/ILICheck.Web/Controllers/UploadController.cs
+++ b/src/ILICheck.Web/Controllers/UploadController.cs
@@ -9,8 +9,8 @@ using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using System.Web;
-using static ILICheck.Web.ValidatorHelper;
 using UAParser;
+using static ILICheck.Web.ValidatorHelper;
 
 namespace ILICheck.Web.Controllers
 {
@@ -102,10 +102,7 @@ namespace ILICheck.Web.Controllers
             }
             else
             {
-                logger.LogInformation("User Agent: {BrowserFamily} {BrowserMajor} on {OSFamily}",
-                    clientInfo.UA.Family,
-                    clientInfo.UA.Major,
-                    clientInfo.OS.Family);
+                logger.LogInformation("User Agent: {BrowserFamily} {BrowserMajor} on {OSFamily}",clientInfo.UA.Family,clientInfo.UA.Major,clientInfo.OS.Family);
             }
 
             try

--- a/src/ILICheck.Web/Controllers/UploadController.cs
+++ b/src/ILICheck.Web/Controllers/UploadController.cs
@@ -102,7 +102,7 @@ namespace ILICheck.Web.Controllers
             }
             else
             {
-                logger.LogInformation("User Agent: {BrowserFamily} {BrowserMajor} on {OSFamily}",clientInfo.UA.Family,clientInfo.UA.Major,clientInfo.OS.Family);
+                logger.LogInformation("User Agent: {BrowserFamily} {BrowserMajor} on {OSFamily}", clientInfo.UA.Family, clientInfo.UA.Major, clientInfo.OS.Family);
             }
 
             try

--- a/src/ILICheck.Web/Controllers/UploadController.cs
+++ b/src/ILICheck.Web/Controllers/UploadController.cs
@@ -95,6 +95,19 @@ namespace ILICheck.Web.Controllers
             logger.LogInformation("Transfer file size: {ContentLength}", HttpUtility.HtmlEncode(httpRequest.ContentLength));
             logger.LogInformation("Start time: {Timestamp}", DateTime.Now);
 
+            // Log raw User Agent string if library can't detect which one it is.
+            if (clientInfo.UA.Family == "Other")
+            {
+                logger.LogInformation("User Agent: {RawUA}", userAgentString);
+            }
+            else
+            {
+                logger.LogInformation("User Agent: {BrowserFamily} {BrowserMajor} on {OSFamily}",
+                    clientInfo.UA.Family,
+                    clientInfo.UA.Major,
+                    clientInfo.OS.Family);
+            }
+
             try
             {
                 // Sanitize file name and save the file to the predefined home directory.

--- a/src/ILICheck.Web/Controllers/UploadController.cs
+++ b/src/ILICheck.Web/Controllers/UploadController.cs
@@ -98,7 +98,8 @@ namespace ILICheck.Web.Controllers
             // Log raw User Agent string if library can't detect which one it is.
             if (clientInfo.UA.Family == "Other")
             {
-                logger.LogInformation("User Agent: {RawUA}", userAgentString);
+                var sanitizedUserAgentString = HttpUtility.HtmlEncode(userAgentString).Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                logger.LogInformation("User Agent: {RawUA}", sanitizedUserAgentString);
             }
             else
             {

--- a/src/ILICheck.Web/Controllers/UploadController.cs
+++ b/src/ILICheck.Web/Controllers/UploadController.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Web;
 using static ILICheck.Web.ValidatorHelper;
+using UAParser;
 
 namespace ILICheck.Web.Controllers
 {

--- a/src/ILICheck.Web/Controllers/UploadController.cs
+++ b/src/ILICheck.Web/Controllers/UploadController.cs
@@ -84,7 +84,12 @@ namespace ILICheck.Web.Controllers
         public async Task<IActionResult> UploadAsync(ApiVersion version, IFormFile file)
         {
             if (file == null) return Problem($"Form data <{nameof(file)}> cannot be empty.", statusCode: StatusCodes.Status400BadRequest);
+
             var httpRequest = httpContextAccessor.HttpContext.Request;
+            var userAgentString = httpRequest.Headers["User-Agent"].ToString();
+
+            var uaParser = Parser.GetDefault();
+            var clientInfo = uaParser.Parse(userAgentString);
 
             logger.LogInformation("Start uploading <{TransferFile}> to <{HomeDirectory}>", file.FileName, fileProvider.HomeDirectory);
             logger.LogInformation("Transfer file size: {ContentLength}", HttpUtility.HtmlEncode(httpRequest.ContentLength));

--- a/src/ILICheck.Web/ILICheck.Web.csproj
+++ b/src/ILICheck.Web/ILICheck.Web.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.1" />
+    <PackageReference Include="UAParser" Version="3.1.47" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Additions

- Added library to parse User Agent headers because they're messy as all hell. If we wanna do it in-house im cool with that too, will rewrite the code.
- Library has issues detecting anything that isn't a browser it seems (For example, for Postman it just spit out "Other" which i don't find very useful). For that reason, if it can't detect what User Agent it is and declares it as other, we print the raw User Agent header from the http request instead. It gives us more information even if it has the potential to be a bit messier.