### PR TITLE
Allow use of empty string for default profile

### DIFF
--- a/src/Ilicop.Web/Controllers/UploadController.cs
+++ b/src/Ilicop.Web/Controllers/UploadController.cs
@@ -57,7 +57,7 @@ namespace Geowerkstatt.Ilicop.Web.Controllers
         /// </summary>
         /// <param name="version">The application programming interface (API) version.</param>
         /// <param name="file">The transfer or ZIP file to validate.</param>
-        /// <param name="profileId">The ID of the validation profile to be used for validation. Defaults to "DEFAULT".</param>
+        /// <param name="profileId">The ID of the validation profile to be used for validation. Null and empty string default to "DEFAULT".</param>
         /// <remarks>
         /// ## Usage
         /// 
@@ -97,7 +97,7 @@ namespace Geowerkstatt.Ilicop.Web.Controllers
         [SwaggerResponse(StatusCodes.Status413PayloadTooLarge, "The transfer file is too large. Max allowed request body size is 200 MB.")]
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1629:DocumentationTextMustEndWithAPeriod", Justification = "Not applicable for code examples.")]
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1028:CodeMustNotContainTrailingWhitespace", Justification = "Not applicable for code examples.")]
-        public async Task<IActionResult> UploadAsync(ApiVersion version, IFormFile file, [FromForm] string profileId = DefaultProfileId)
+        public async Task<IActionResult> UploadAsync(ApiVersion version, IFormFile file, [FromForm] string profileId)
         {
             if (file == null) return Problem($"Form data <{nameof(file)}> cannot be empty.", statusCode: StatusCodes.Status400BadRequest);
 
@@ -117,6 +117,8 @@ namespace Geowerkstatt.Ilicop.Web.Controllers
 
             try
             {
+                if (string.IsNullOrEmpty(profileId)) profileId = DefaultProfileId;
+
                 // Check if validation profile exists
                 var profiles = await profileService.GetProfiles();
                 var profile = profiles.First(p => p.Id == profileId);

--- a/tests/Ilicop.Web.Test/UploadControllerTest.cs
+++ b/tests/Ilicop.Web.Test/UploadControllerTest.cs
@@ -97,7 +97,7 @@ namespace Geowerkstatt.Ilicop.Web.Controllers
         [TestMethod]
         [DataRow(null)]
         [DataRow("")]
-        public async Task UploadAsyncWithoutExplicitProfile(string profileId)
+        public async Task UploadAsyncWithoutExplicitProfile(string profile)
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Request.ContentLength = 1234;
@@ -109,7 +109,7 @@ namespace Geowerkstatt.Ilicop.Web.Controllers
                 It.IsAny<Func<CancellationToken, Task>>())).Returns(Task.FromResult(0));
             profileServiceMock.Setup(x => x.GetProfiles()).ReturnsAsync(new List<Profile> { new Profile { Id = "DEFAULT" } });
 
-            var response = await controller.UploadAsync(apiVersionMock.Object, formFileMock.Object, profileId) as CreatedResult;
+            var response = await controller.UploadAsync(apiVersionMock.Object, formFileMock.Object, profile) as CreatedResult;
 
             Assert.IsInstanceOfType(response, typeof(CreatedResult));
             Assert.IsInstanceOfType(response.Value, typeof(UploadResponse));
@@ -120,7 +120,7 @@ namespace Geowerkstatt.Ilicop.Web.Controllers
         [DataRow("")]
         [DataRow(null)]
         [DataRow("DEFAULT")]
-        public async Task DefaultValidationWithoutDefaultProfileReturnsBadRequest(string profileId)
+        public async Task DefaultValidationWithoutDefaultProfileReturnsBadRequest(string profile)
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Request.ContentLength = 1234;
@@ -128,7 +128,7 @@ namespace Geowerkstatt.Ilicop.Web.Controllers
             formFileMock.SetupGet(x => x.FileName).Returns("BIZARRESCAN.xtf");
             profileServiceMock.Setup(x => x.GetProfiles()).ReturnsAsync(new List<Profile> { new Profile { Id = "test-profile" } });
 
-            var response = await controller.UploadAsync(apiVersionMock.Object, formFileMock.Object, profileId) as ObjectResult;
+            var response = await controller.UploadAsync(apiVersionMock.Object, formFileMock.Object, profile) as ObjectResult;
             var problemDetails = response?.Value as ProblemDetails;
 
             Assert.IsInstanceOfType(response, typeof(ObjectResult));


### PR DESCRIPTION
Resolves: #302 

Vorheriges verhalten:
Wenn bei einer Validierung ein leerer String als Profil ID mitgegeben wird, wird nach einem Profil mit einem leeren String als Profil ID gesucht. Im Normalfall existiert dieses Profil nicht. --> 400 Bad Request: The specified profile <> does not exist.

Neues verhalten:
Wenn bei einer Validierung ein leerer String als Profil ID mitgegeben wird, wird das Default-Profil gewählt.

Begründung für Änderung:
UploadAsync wird mit Form-Data aufgerufen und bei Form-Data ist es üblich, dass nicht definierte Felder durch einen leeren String repräsentiert werden. So können z.B. bei HTML Forms keine Felder auf Null gesetzt werden, sondern werden automatisch zu einem leeren String. Aus diesem Grund muss ein leerer String als Null und somit schlussendlich als Default-Profil interpretiert werden.
Auch beim geopilot führt es zu Problemen, wenn nicht ein leerer String verwendet werden kann.

Bemerkung zur Implementierung:
Der Default-Wert bei der Definition von UploadAsync wurde entfernt, da ein Empty-String check neu sowieso notwendig ist. So ist die Behandlung von Null und Empty String am gleichen Ort und einfacher verständlich.