### PR TITLE
Custom upload limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ services:
     #   - CUSTOM_VENDOR_LINK=https://www.example.com
     #     Optional link to the vendors webpage
     #     The link is only taken into account if there is a corresponding vendor.png
+    #
+    #   - ILICOP_MAX_UPLOAD_SIZE_MB=200
+    #     Optional maximum upload size in megabytes
+    #     Default 200 MB
     environment:
       - PUID=1000
       - PGID=1000

--- a/src/Ilicop.Web/ClientApp/src/dropzone.jsx
+++ b/src/Ilicop.Web/ClientApp/src/dropzone.jsx
@@ -93,7 +93,7 @@ export const FileDropzone = ({
     onDropAccepted,
     onDropRejected,
     maxFiles: 1,
-    maxSize: maxUploadSizeBytes ?? 209715200 // 200 MB,
+    maxSize: maxUploadSizeBytes ?? 209715200, // 200 MB
     accept: acceptedFileTypes,
   });
 

--- a/src/Ilicop.Web/ClientApp/src/dropzone.jsx
+++ b/src/Ilicop.Web/ClientApp/src/dropzone.jsx
@@ -33,6 +33,7 @@ const Container = styled.div`
 
 export const FileDropzone = ({
   acceptedFileTypes,
+  maxUploadSizeBytes,
   fileToCheck,
   fileToCheckRef,
   setFileToCheck,
@@ -92,7 +93,7 @@ export const FileDropzone = ({
     onDropAccepted,
     onDropRejected,
     maxFiles: 1,
-    maxSize: 209715200,
+    maxSize: maxUploadSizeBytes ?? 209715200 // 200 MB,
     accept: acceptedFileTypes,
   });
 

--- a/src/Ilicop.Web/ClientApp/src/home.jsx
+++ b/src/Ilicop.Web/ClientApp/src/home.jsx
@@ -131,6 +131,7 @@ export const Home = (props) => {
       <Container>
         <FileDropzone
           acceptedFileTypes={clientSettings?.acceptedFileTypes}
+          maxUploadSizeBytes={clientSettings?.maxUploadSizeBytes}
           fileToCheck={fileToCheck}
           fileToCheckRef={fileToCheckRef}
           setFileToCheck={setFileToCheck}

--- a/src/Ilicop.Web/Contracts/SettingsResponse.cs
+++ b/src/Ilicop.Web/Contracts/SettingsResponse.cs
@@ -41,5 +41,10 @@ namespace Geowerkstatt.Ilicop.Web.Contracts
         /// </summary>
         [Required]
         public string AcceptedFileTypes { get; set; }
+
+        /// <summary>
+        /// The maximum upload size in bytes if configured; otherwise, <c>null</c>.
+        /// </summary>
+        public int? MaxUploadSizeBytes { get; set; }
     }
 }

--- a/src/Ilicop.Web/Controllers/SettingsController.cs
+++ b/src/Ilicop.Web/Controllers/SettingsController.cs
@@ -44,6 +44,7 @@ namespace Geowerkstatt.Ilicop.Web.Controllers
                     ? (ilitoolsEnvironment.Ili2GpkgVersion ?? "undefined/not configured")
                     : "disabled",
                 AcceptedFileTypes = GetAcceptedFileExtensionsForUserUploads(configuration).JoinNonEmpty(", "),
+                MaxUploadSizeBytes = configuration.GetValue<int?>("ILICOP_MAX_UPLOAD_SIZE_MB") is int mb ? mb * 1024 * 1024 : null,
             });
         }
     }

--- a/src/Ilicop.Web/Controllers/UploadController.cs
+++ b/src/Ilicop.Web/Controllers/UploadController.cs
@@ -95,7 +95,7 @@ namespace Geowerkstatt.Ilicop.Web.Controllers
         [HttpPost]
         [SwaggerResponse(StatusCodes.Status201Created, "The validation job was successfully created and is now scheduled for execution.", typeof(UploadResponse), "application/json")]
         [SwaggerResponse(StatusCodes.Status400BadRequest, "The server cannot process the request due to invalid or malformed request.", typeof(ProblemDetails), "application/json")]
-        [SwaggerResponse(StatusCodes.Status413PayloadTooLarge, "The transfer file is too large. Max allowed request body size is 200 MB.")]
+        [SwaggerResponse(StatusCodes.Status413PayloadTooLarge, "The transfer file is too large.")]
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1629:DocumentationTextMustEndWithAPeriod", Justification = "Not applicable for code examples.")]
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1028:CodeMustNotContainTrailingWhitespace", Justification = "Not applicable for code examples.")]
         public async Task<IActionResult> UploadAsync(ApiVersion version, IFormFile file, [FromForm] string profile)

--- a/src/Ilicop.Web/Startup.cs
+++ b/src/Ilicop.Web/Startup.cs
@@ -26,11 +26,14 @@ namespace Geowerkstatt.Ilicop.Web
 {
     public class Startup
     {
-        private const int MaxRequestBodySize = 209715200;
+        private readonly int maxRequestBodySize;
 
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
+
+            var configuredSizeMb = configuration.GetValue<int?>("ILICOP_MAX_UPLOAD_SIZE_MB");
+            maxRequestBodySize = configuredSizeMb.HasValue ? configuredSizeMb.Value * 1024 * 1024 : 209715200;
         }
 
         public IConfiguration Configuration { get; }
@@ -110,11 +113,11 @@ namespace Geowerkstatt.Ilicop.Web
             });
             services.Configure<FormOptions>(options =>
             {
-                options.MultipartBodyLengthLimit = MaxRequestBodySize;
+                options.MultipartBodyLengthLimit = maxRequestBodySize;
             });
             services.Configure<KestrelServerOptions>(options =>
             {
-                options.Limits.MaxRequestBodySize = MaxRequestBodySize;
+                options.Limits.MaxRequestBodySize = maxRequestBodySize;
             });
             services.Configure<RouteOptions>(options => options.LowercaseUrls = true);
             services.AddSwaggerGen(options =>
@@ -156,7 +159,7 @@ namespace Geowerkstatt.Ilicop.Web
             // By default Kestrel responds with a HTTP 400 if payload is too large.
             app.Use(async (context, next) =>
             {
-                if (context.Request.ContentLength > MaxRequestBodySize)
+                if (context.Request.ContentLength > maxRequestBodySize)
                 {
                     context.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
                     await context.Response.WriteAsync("Payload Too Large");


### PR DESCRIPTION
- Read `ILICOP_MAX_UPLOAD_SIZE_MB` from env to configure a custom upload limit. Completely optional, falls back to default 200 MB.
- Frontend is made aware of the upload limit on runtime via the settings endpoint. If no limit is configured, falls back to default 200 MB. Added for nicer UX.